### PR TITLE
Display <br> as block

### DIFF
--- a/System.Drawing.Html/CssDefaults.cs
+++ b/System.Drawing.Html/CssDefaults.cs
@@ -23,7 +23,7 @@ namespace System.Drawing.Html
         h1, h2, h3, h4,
         h5, h6, noframes,
         ol, p, ul, center,
-        dir, hr, menu, pre   { display: block }
+        dir, hr, menu, pre, br   { display: block }
         li              { display: list-item }
         head            { display: none }
         table           { display: table }


### PR DESCRIPTION
css2 br line breaks are handled by 
br:before{ content: ""\A"" }
Unitl  ::before pseudo element is implemented, displaying <br> produces the correct behavior